### PR TITLE
use shiny new features of cryfsm

### DIFF
--- a/code/circuits/point-json.py
+++ b/code/circuits/point-json.py
@@ -18,12 +18,8 @@ def run(lst):
 
 def binary_point(bitlength):
     secret = random_bitstring(bitlength)
-    array = '['
-    for x in range(1, bitlength + 1):
-        array += '"%d", ' % x
-    array += '"%d"]' % (bitlength + 1)
     lst = ['cryfsm', '-e', "(==) 0b%s" % secret, '-v', "\_ -> True", '-g',
-           array, '-o', 'point-%d.json' % bitlength]
+           '#', '-o', 'point-%d.json' % bitlength]
     run(lst)
     with open('point-%d.json' % bitlength, 'r') as f:
         line = f.read()

--- a/code/obf/sz_bp.py
+++ b/code/obf/sz_bp.py
@@ -61,9 +61,19 @@ class SZBranchingProgram(AbstractBranchingProgram):
                 for line in f:
                     if line.startswith('#'):
                         continue
+                    bp_json = json.loads(line)
                     for idx, step in enumerate(json.loads(line)['steps']):
                         bp.append(
                             Layer(idx, matrix(step['0']), matrix(step['1'])))
+
+                    assert len(bp_json['outputs'])    == 1 and \
+                           len(bp_json['outputs'][0]) == 2
+                    first_out = bp_json['outputs'][0][0].lower()
+                    if first_out not in ['false', '0']:
+                        if first_out not in ['true', '1']:
+                            print('warning: interpreting %s as a truthy output' % first_out)
+                        bp[-1].zero.swap_columns(0,1)
+                        bp[-1].one .swap_columns(0,1)
                     return bp
         except IOError as e:
             print(e)

--- a/code/obf/sz_bp.py
+++ b/code/obf/sz_bp.py
@@ -62,9 +62,9 @@ class SZBranchingProgram(AbstractBranchingProgram):
                     if line.startswith('#'):
                         continue
                     bp_json = json.loads(line)
-                    for idx, step in enumerate(json.loads(line)['steps']):
+                    for step in bp_json['steps']:
                         bp.append(
-                            Layer(idx, matrix(step['0']), matrix(step['1'])))
+                            Layer(int(step['position']), matrix(step['0']), matrix(step['1'])))
 
                     assert len(bp_json['outputs'])    == 1 and \
                            len(bp_json['outputs'][0]) == 2
@@ -76,6 +76,10 @@ class SZBranchingProgram(AbstractBranchingProgram):
                         bp[-1].one .swap_columns(0,1)
                     return bp
         except IOError as e:
+            print(e)
+            sys.exit(1)
+        except ValueError as e:
+            print('expected numeric position while parsing branching program JSON')
             print(e)
             sys.exit(1)
 


### PR DESCRIPTION
cryfsm has grown two smallish features:

1. It reports the output of compiled functions in "outputs" rather than the input to the function.
2. It has an "obfuscation mode" (invoked via `-g #`) that chooses positions automatically, numbering positions sequentially from 0.

The following commits are tweaks that take advantage of these new features. I comment on them briefly here:

* "check the outputs" -- the JSON format doesn't really make a promise about which output "state" is considered the "1" output and which is considered the "0" output. But it does give a string for each output state, and this was being ignored by the parser. The new parser will try to make a sane guess about which output state should be considered the "1" state. (To see this go wrong with the old parser, try testing all the one-bit point functions produced by cryfsm.)

    If you apply this patch, you should pull the newest cryfsm and recreate your JSON files.

* "use cryfsm's obfuscation mode" -- not really necessary. But works together with the next patch nicely, as it asks cryfsm to produce the appropriate information in the "position" field of each step.

    If you apply this patch, you should pull the newest cryfsm. You do not need to recreate any JSON files.

* "preserve position information from JSON bps" -- likely the most controversial patch in the set. It changes the meaning of JSON input files. Instead of the array of steps being forced into lockstep with the input bits, it lets the "position" field decide which input bit is associated with each step. I think the parser used to do this and was changed not to -- whatever desiderata was used for that should be considered again before accepting this patch. I will say that one nice thing about letting the "position" field be meaningful is that it expands the set of matrix branching programs that can be represented by this format; cryfsm doesn't (currently) take advantage of that expanded set, but it or other tools like it presumably could in the future.

    If you apply this patch, you need not change anything about cryfsm, but should regenerate any 1-indexed JSON files you have lying around to be 0-indexed.